### PR TITLE
support for WORKDIR & raw Dockerfile instruction

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -73,6 +73,14 @@ class DockerTask extends DefaultTask {
         instructions.add("ADD ${copySpec} ${destPath}")
     }
 
+    void workingDir(String wd) {
+        instructions.add("WORKDIR ${wd}")
+    }
+
+    void instruction(String cmd, String value) {
+        instructions.add("${cmd} ${value}")
+    }
+
     void runCommand(String command) {
         instructions.add("RUN ${command}")
     }


### PR DESCRIPTION
This commit adds support for WORKDIR instruction and any raw Dockerfile instructions.

e.g.
workingDir("/opt/installed")
instruction("WORKDIR", "/opt/installed")
