### PR TITLE
Fix for running tests on Windows

### DIFF
--- a/src/integTest/groovy/se/transmode/gradle/plugins/docker/CreateDockerfileTest.groovy
+++ b/src/integTest/groovy/se/transmode/gradle/plugins/docker/CreateDockerfileTest.groovy
@@ -43,7 +43,7 @@ class CreateDockerfileTest {
         task.runCommand "apt-get install -y inotify-tools nginx apache2 openssh-server"
 
         def expectedDockerFile = this.getClass().getResource("nginx.Dockerfile").text.trim()
-        def actualDockerFile = task.buildDockerFile().join("\n")
+        def actualDockerFile = task.buildDockerFile().join(System.getProperty('line.separator'))
 
         assertThat actualDockerFile, is(equalTo(expectedDockerFile))
     }


### PR DESCRIPTION
Need to use the portable line separator since the docker file on windows
will use native line endings (given that it is just a text file)
