### PR TITLE
Handling error of docker process execution.

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -16,6 +16,7 @@
 package se.transmode.gradle.plugins.docker
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.TaskAction
@@ -158,6 +159,9 @@ class DockerTask extends DefaultTask {
         logger.info("Executing command '" + cmdLine + "'.")
         def process = cmdLine.execute()
         process.waitFor()
+        if (process.exitValue() != 0) {
+           throw new GradleException("docker execution failed\nCommand line [${cmdLine}] returned:\n${process.err.text}")
+        }
         return process.in.text
     }
 


### PR DESCRIPTION
At the moment if for some reason the docker process fails no information is given to the user and the build ends with success. This patch checks the return states of the docker process, throws an exception if something went wrong and the process stderr is returned.
