### PR TITLE
Implement a Docker "run" task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,13 @@ configurations {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.google.guava:guava:17.0'
 
     compile 'com.google.guava:guava:17.0'
-    compile 'com.github.docker-java:docker-java:0.9.0'
+    compile 'com.github.docker-java:docker-java:0.9.1'
 
     testCompile 'junit:junit-dep:4.11'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.mockito:mockito-core:1.9.5'
 }
 
 task integTest(type: Test) {

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPlugin.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPlugin.groovy
@@ -33,11 +33,13 @@ class DockerPlugin implements Plugin<Project> {
     void apply(Project project) {
         this.extension = createExtension(project)
         addDockerTaskType(project)
+        addDockerRunTaskType(project)
         project.plugins.withType(ApplicationPlugin).all {
             logger.info('Detected application plugin.')
             addDistDockerTask(project)
         }
         configureDockerTasks(project)
+        configureDockerRunTasks(project)
     }
 
     private void addDistDockerTask(Project project) {
@@ -63,6 +65,11 @@ class DockerPlugin implements Plugin<Project> {
         project.ext.Docker = DockerTask.class
     }
 
+    private void addDockerRunTaskType(Project project) {
+        project.ext.DockerRun = DockerRunTask.class
+        logger.info("Adding docker run task type");
+    }
+
     private DockerPluginExtension createExtension(Project project) {
         def extension = project.extensions.create(EXTENSION_NAME, DockerPluginExtension)
         extension.with {
@@ -86,12 +93,33 @@ class DockerPlugin implements Plugin<Project> {
         }
     }
 
+    private void configureDockerRunTasks(Project project) {
+        project.tasks.withType(DockerRunTask.class).all { task ->
+            applyRunTaskDefaults(task)
+        }
+        logger.info("Applying docker defaults to tasks of type 'DockerRun'");
+    }
+
     private void applyTaskDefaults(task) {
         // @todo: don't use conventionMapping as it is an internal mechanism
         //        see http://forums.gradle.org/gradle/topics/how_do_you_use_a_conventionmapping_to_do_the_following
         task.conventionMapping.with {
             dockerBinary = { extension.dockerBinary }
             maintainer = { extension.maintainer }
+            registry = { extension.registry }
+            useApi = { extension.useApi }
+            hostUrl = { extension.hostUrl }
+            apiUsername = { extension.apiUsername }
+            apiPassword = { extension.apiPassword }
+            apiEmail = { extension.apiEmail }
+        }
+    }
+    
+    private void applyRunTaskDefaults(task) {
+        // @todo: don't use conventionMapping as it is an internal mechanism
+        //        see http://forums.gradle.org/gradle/topics/how_do_you_use_a_conventionmapping_to_do_the_following
+        task.conventionMapping.with {
+            dockerBinary = { extension.dockerBinary }
             registry = { extension.registry }
             useApi = { extension.useApi }
             hostUrl = { extension.hostUrl }

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerRunTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerRunTask.groovy
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2014 Transmode AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.transmode.gradle.plugins.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.TaskAction;
+
+import se.transmode.gradle.plugins.docker.client.DockerClient
+
+class DockerRunTask extends DockerTaskBase {
+    private static Logger logger = Logging.getLogger(DockerRunTask)
+    
+    String containerName
+    
+    boolean detached = false
+
+    boolean autoRemove = false
+    
+    Map<String, String> env
+    
+    Map<String, String> ports
+    
+    Map<String, String> volumes
+    
+    List<String> volumesFrom
+    
+    List<String> links
+    
+    DockerRunTask() {
+        env = [:]
+        ports = [:]
+        volumes = [:]
+        volumesFrom = []
+        links = []
+    }
+    
+    @TaskAction
+    public void run() {
+        DockerClient client = getClient()
+        client.run(getImageTag(), getContainerName(), getDetached(), getAutoRemove(), getEnv(), 
+            getPorts(), getVolumes(), getVolumesFrom(), getLinks())
+    }
+    
+    void env(String key, String value) {
+        env.put(key, value)
+    }
+    
+    void publish(String host, String container) {
+        ports.put(host, container)
+    }
+    
+    void volume(String host, String container) {
+        volumes.put(host, container)
+    }
+    
+    void volumesFrom(String containerName) {
+        volumesFrom.add(containerName)
+    }
+    
+    void link(String containerName) {
+        links.add(containerName)
+    }
+}

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTaskBase.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTaskBase.groovy
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2014 Transmode AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.transmode.gradle.plugins.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.Logger
+
+import com.google.common.annotations.VisibleForTesting;
+
+import se.transmode.gradle.plugins.docker.client.DockerClient
+import se.transmode.gradle.plugins.docker.client.JavaDockerClient
+import se.transmode.gradle.plugins.docker.client.NativeDockerClient
+
+abstract class DockerTaskBase extends DefaultTask {
+
+    @VisibleForTesting
+    static final String LATEST_VERSION = 'latest'
+    
+    // Name of the application being wrapped into a docker image (default: project.name)
+    String applicationName
+    // What to tag the created docker image with (default: group/applicationName)
+    String tag
+    // Which version to use along with the tag (default: latest)
+    String tagVersion
+    // Hostname, port of the docker image registry unless Docker index is used
+    String registry
+
+    // Should we use Docker's remote API instead of the docker executable
+    Boolean useApi
+    
+    // Full path to the docker executable
+    String dockerBinary
+    
+    // URL of the remote Docker host (default: localhost)
+    String hostUrl
+    
+    // Docker remote API credentials
+    String apiUsername
+    String apiPassword
+    String apiEmail
+    
+    DockerTaskBase() {
+        applicationName = project.name
+    }
+
+    void setTagVersion(String version) {
+        tagVersion = version;
+    }
+
+    void setTagVersionToLatest() {
+        tagVersion = LATEST_VERSION;
+    }
+
+    protected String getImageTag() {
+        String tag
+        tag = this.tag ?: getDefaultImageTag()
+        return appendImageTagVersion(tag)
+    }
+
+    private String getDefaultImageTag() {
+        String tag
+        if (registry) {
+            tag = "${-> registry}/${-> applicationName}"
+        } else if (project.group) {
+            tag = "${-> project.group}/${-> applicationName}"
+        } else {
+            tag = "${-> applicationName}"
+        }
+        return tag
+    }
+
+    private String appendImageTagVersion(String tag) {
+        def version = tagVersion ?: project.version
+        if(version == 'unspecified') {
+            version = LATEST_VERSION
+        }
+        return "${tag}:${version}"
+
+    }
+
+    protected DockerClient getClient() {
+        DockerClient client
+        if(getUseApi()) {
+            logger.info("Using the Docker remote API.")
+            client = JavaDockerClient.create(
+                    getHostUrl(),
+                    getApiUsername(),
+                    getApiPassword(),
+                    getApiEmail())
+        } else {
+            logger.info("Using the native docker binary.")
+            client = new NativeDockerClient(getDockerBinary())
+        }
+        return client
+    }
+
+}

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
@@ -15,7 +15,12 @@
  */
 package se.transmode.gradle.plugins.docker.client
 
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.base.Preconditions
+
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException
 
 class NativeDockerClient implements DockerClient {
@@ -43,11 +48,56 @@ class NativeDockerClient implements DockerClient {
 
     private static String executeAndWait(String cmdLine) {
         def process = cmdLine.execute()
-        process.waitFor()
+        process.waitForProcessOutput(System.out, System.err)
         if (process.exitValue()) {
-            throw new GradleException("Docker execution failed\nCommand line [${cmdLine}] returned:\n${process.err.text}")
+            throw new GradleException("Docker execution failed\nCommand line [${cmdLine}]")
         }
-        return process.in.text
+        return "Done"
+    }
+
+    @Override
+    String run(String tag, String containerName, boolean detached, boolean autoRemove, 
+            Map<String, String> env,
+            Map<String, String> ports, Map<String, String> volumes, List<String> volumesFrom,
+            List<String> links) {
+        Preconditions.checkArgument(tag as Boolean,  "Image tag cannot be empty or null.")
+        Preconditions.checkArgument(containerName as Boolean,  "Image name cannot be empty or null.")
+        Preconditions.checkArgument(env != null,  "Environment map cannot be null.")
+        Preconditions.checkArgument(ports != null,  "Exported port map cannot be null.")
+        Preconditions.checkArgument(volumes != null,  "Volume map cannot be null.")
+        Preconditions.checkArgument(volumesFrom != null,  "Volumes from list cannot be null.")
+        Preconditions.checkArgument(links != null,  "Link list cannot be null.")
+        Preconditions.checkArgument(!detached || !autoRemove,
+            "Cannot set both detached and autoRemove options to true.");
+
+        def detachedArg = detached ? '-d' : ''
+        def removeArg = autoRemove ? '--rm' : ''
+        def cmdLine = "${binary} run ${detachedArg} ${removeArg} --name ${containerName}"
+        cmdLine = appendArguments(cmdLine, env, "--env", '=')
+        cmdLine = appendArguments(cmdLine, ports, "--publish")
+        cmdLine = appendArguments(cmdLine, volumes, "--volume")
+        cmdLine = appendArguments(cmdLine, volumesFrom, "--volumes-from")
+        cmdLine = appendArguments(cmdLine, links, "--link")
+        cmdLine = "${cmdLine} ${tag}"
+        return executeAndWait(cmdLine)
+    }
+
+    private String appendArguments(String cmdLine, Map<String, String> map, String option, 
+            String separator = ':') {
+        // Add each entry in the map as the indicated argument
+        map.each { key, value ->
+            cmdLine = "${cmdLine} ${option} ${key}${separator}${value}"
+        }
+        return cmdLine
+    }
+
+            
+    private String appendArguments(String cmdLine, List<String> list, String option) {
+        // Add each entry in the map as the indicated argument
+        list.each {
+            cmdLine = "${cmdLine} ${option} ${it}"
+        }
+        return cmdLine
     }
 
 }

--- a/src/main/java/se/transmode/gradle/plugins/docker/client/DockerClient.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/client/DockerClient.java
@@ -16,8 +16,42 @@
 package se.transmode.gradle.plugins.docker.client;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 public interface DockerClient {
+    /**
+     * Build a Docker image from the contents of the given directory.
+     * 
+     * @param buildDir the directory from which to build the image
+     * @param tag the tag to apply to the image
+     * @return the output of the command
+     */
     public String buildImage(File buildDir, String tag);
+    
+    /**
+     * Push the given image to the configured Docker registry.
+     * 
+     * @param tag the tag of the image to push
+     * @return the output of the command
+     */
     public String pushImage(String tag);
+    
+    /**
+     * Run the given image in a container with the given name.
+     * 
+     * @param tag the image to run
+     * @param containerName the name of the container to create
+     * @param detached should the container be run in the background (aka detached)
+     * @param autoRemove should the container be removed when execution completes
+     * @param env a map containing a collection of environment variables to set
+     * @param ports a map containing the ports to publish
+     * @param volumes a map containing the volumes to bind
+     * @param volumesFrom a list of the containers whose volumes we should mount
+     * @param links a list of the containers to which the newly created container should be linked
+     * @return the output of the command
+     */
+    public String run(String tag, String containerName, boolean detached, boolean autoRemove,
+            Map<String, String> env, Map<String, String> ports, Map<String, String> volumes, 
+            List<String> volumesFrom, List<String> links);
 }

--- a/src/test/groovy/se/transmode/gradle/plugins/docker/DockerRunTaskTest.groovy
+++ b/src/test/groovy/se/transmode/gradle/plugins/docker/DockerRunTaskTest.groovy
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2014 Transmode AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.transmode.gradle.plugins.docker
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import org.mockito.ArgumentMatcher;
+import org.mockito.stubbing.Answer;
+
+import se.transmode.gradle.plugins.docker.client.DockerClient;
+import static org.junit.Assert.assertTrue
+import static org.mockito.Mockito.*;
+
+class DockerRunTaskTest {
+    
+    public static class TestDockerRunTask extends DockerRunTask {
+        
+        DockerClient mockClient;
+        
+        TestDockerRunTask() {
+            mockClient = mock(DockerClient.class)
+        }
+
+        @Override
+        protected DockerClient getClient() {
+            return mockClient;
+        }
+        
+    }
+    
+    private static ArgumentMatcher<Collection<?>> isEmptyCollection = 
+        new ArgumentMatcher<Collection<?>>() {
+            
+            @Override
+            public boolean matches(Object collection) {
+                return (collection != null) && ((Collection) collection).size() == 0;
+            }
+    
+    }
+        
+    private static ArgumentMatcher<Collection<?>> isSingletonCollection = 
+        new ArgumentMatcher<Collection<?>>() {
+            
+            @Override
+            public boolean matches(Object collection) {
+                return (collection != null) && ((Collection) collection).size() == 1;
+            }
+    
+    }
+        
+    private static ArgumentMatcher<Map<?, ?>> isEmptyMap = 
+        new ArgumentMatcher<Map<?, ?>>() {
+            
+            @Override
+            public boolean matches(Object map) {
+                return (map != null) && ((Map) map).size() == 0;
+            }
+    
+    }
+        
+    private static ArgumentMatcher<Map<?, ?>> isSingletonMap = 
+        new ArgumentMatcher<Map<?, ?>>() {
+            
+            @Override
+            public boolean matches(Object map) {
+                return (map != null) && ((Map) map).size() == 1;
+            }
+    
+    }
+
+    private static final String CONTAINER_NAME = 'mycontainer'
+        
+    private Project createProject() {
+        Project project = ProjectBuilder.builder().build()
+        // apply java plugin
+        project.apply plugin: 'java'
+        // add docker extension
+        project.extensions.create(DockerPlugin.EXTENSION_NAME, DockerPluginExtension)
+        // add docker run task configured to return a mock client
+        project.task('dockerRunTask', type: TestDockerRunTask)
+        return project
+    }
+    
+    @Test
+    public void addTaskToProject() {
+        def task = ProjectBuilder.builder().build().task('dockerTask', type: DockerRunTask)
+        assertTrue(task instanceof DockerRunTask)
+    }
+    
+    @Test
+    public void runDefault() {
+        def project = createProject()
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runNamedContainer() {
+        def project = createProject()
+        project.dockerRunTask.containerName = CONTAINER_NAME
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(CONTAINER_NAME),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+
+    @Test
+    public void runDetached() {
+        def project = createProject()
+        project.dockerRunTask.detached = true
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(true), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runAutoRemove() {
+        def project = createProject()
+        project.dockerRunTask.autoRemove = true
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(true), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runWithEnv() {
+        def project = createProject()
+        project.dockerRunTask.env("foo", "bar")
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isSingletonMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runWithPorts() {
+        def project = createProject()
+        project.dockerRunTask.publish("foo", "bar")
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isSingletonMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runWithVolumes() {
+        def project = createProject()
+        project.dockerRunTask.volume("foo", "bar")
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isSingletonMap), argThat(isEmptyCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runWithVolumesFrom() {
+        def project = createProject()
+        project.dockerRunTask.volumesFrom("foo")
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isSingletonCollection), argThat(isEmptyCollection))
+    }
+    
+    @Test
+    public void runWithLinks() {
+        def project = createProject()
+        project.dockerRunTask.link("foo")
+        project.dockerRunTask.run()
+        verify(project.dockerRunTask.mockClient).run(anyString(), eq(null),
+            eq(false), eq(false), argThat(isEmptyMap), argThat(isEmptyMap), 
+            argThat(isEmptyMap), argThat(isEmptyCollection), argThat(isSingletonCollection))
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void runIllegalTaskState() {
+        // Create project without the client mocked
+        Project project = ProjectBuilder.builder().build()
+        project.apply plugin: 'java'
+        project.extensions.create(DockerPlugin.EXTENSION_NAME, DockerPluginExtension)
+        project.task('dockerRunTask', type: DockerRunTask)
+        
+        // Configure the task to be both detached and auto-remove
+        project.dockerRunTask.detached = true
+        project.dockerRunTask.autoRemove = true
+        project.dockerRunTask.run()
+    }
+}

--- a/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskBaseTest.groovy
+++ b/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskBaseTest.groovy
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2014 Transmode AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.transmode.gradle.plugins.docker
+
+import static org.hamcrest.Matchers.*
+import static org.junit.Assert.*
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.hamcrest.Matchers
+import org.junit.Test
+
+import se.transmode.gradle.plugins.docker.client.DockerClient
+import se.transmode.gradle.plugins.docker.client.JavaDockerClient;
+import se.transmode.gradle.plugins.docker.client.NativeDockerClient
+
+class DockerTaskBaseTest {
+
+    private static final String PROJECT_GROUP = 'mygroup'
+    private static final String REGISTRY = 'myregistry'
+    private static final String PROJECT_VERSION = 'myversion'
+    private static final String TAG_VERSION = 'tagVersion'
+    
+    // Create dummy task sub-class so we can test the functionality provided by the super-class
+    public static class DummyTask extends DockerTaskBase {
+        
+    }
+    
+    private Project createProject() {
+        Project project = ProjectBuilder.builder().build()
+        // apply java plugin
+        project.apply plugin: 'java'
+        // add docker extension
+        project.extensions.create(DockerPlugin.EXTENSION_NAME, DockerPluginExtension)
+        // add dummy task
+        project.task('dummyTask', type: DummyTask)
+        project.dummyTask.dockerBinary = 'true'
+        return project
+    }
+
+    @Test
+    public void getNativeClient() {
+        def project = createProject()
+        DockerClient client = project.dummyTask.getClient()
+        assertThat(client, isA(NativeDockerClient.class))
+    }
+
+    @Test
+    public void getJavaClient() {
+        def project = createProject()
+        project.dummyTask.useApi = true
+        DockerClient client = project.dummyTask.getClient()
+        assertThat(client, isA(JavaDockerClient.class))
+    }
+    
+    @Test
+    public void getImageTag() {
+        def project = createProject()
+
+        // Check the default value
+        def imageTag = project.dummyTask.imageTag
+        assertThat(imageTag, 
+            equalToIgnoringCase("${project.name}:${DockerTaskBase.LATEST_VERSION}"))
+        
+        // A project group should be added to the name
+        project.group = PROJECT_GROUP
+        imageTag = project.dummyTask.imageTag
+        assertThat(imageTag,
+            equalToIgnoringCase("${PROJECT_GROUP}/${project.name}:${DockerTaskBase.LATEST_VERSION}"))
+
+        // If we set the registry that takes precedence
+        project.dummyTask.registry = REGISTRY
+        imageTag = project.dummyTask.imageTag
+        assertThat(imageTag,
+            equalToIgnoringCase("${REGISTRY}/${project.name}:${DockerTaskBase.LATEST_VERSION}"))
+
+        // If the project has a version that should be used
+        project.version = PROJECT_VERSION
+        imageTag = project.dummyTask.imageTag
+        assertThat(imageTag,
+            equalToIgnoringCase("${REGISTRY}/${project.name}:${PROJECT_VERSION}"))
+        
+        // If we set an override version that should be used
+        project.dummyTask.tagVersion = TAG_VERSION
+        imageTag = project.dummyTask.imageTag
+        assertThat(imageTag,
+            equalToIgnoringCase("${REGISTRY}/${project.name}:${TAG_VERSION}"))
+        
+        // Explicitly setting version to latest should use that
+        project.dummyTask.setTagVersionToLatest()
+        imageTag = project.dummyTask.imageTag
+        assertThat(imageTag,
+            equalToIgnoringCase("${REGISTRY}/${project.name}:${DockerTaskBase.LATEST_VERSION}"))
+        
+    }
+}


### PR DESCRIPTION
This adds the ability to perform a Docker "run" via a second task type.  As part of this I refactored code common to both the existing build task and the new run task into an abstract base class.

Note that not all run options are supported at this point, just the ones I needed ;).  More can be added later (within the constraints of the docker-java API).
