### PR TITLE
Prevent hanging on buffered output

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
@@ -43,6 +43,7 @@ class NativeDockerClient implements DockerClient {
 
     private static String executeAndWait(String cmdLine) {
         def process = cmdLine.execute()
+        process.consumeProcessOutput(System.out as OutputStream, System.err as OutputStream)
         process.waitFor()
         if (process.exitValue()) {
             throw new GradleException("Docker execution failed\nCommand line [${cmdLine}] returned:\n${process.err.text}")


### PR DESCRIPTION
The process of docker built is hanging waiting for output to be consumed.