### PR TITLE
Pr spaces in path

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -62,7 +62,7 @@ class DockerTask extends DefaultTask {
 
     /**
      * Name of the base docker image
-    */
+     */
     String baseImage
     public String getBaseImage() {
         return determineBaseImage()
@@ -88,7 +88,7 @@ class DockerTask extends DefaultTask {
     File stageDir
     // Tasks necessary to setup the stage before building an image
     def stageBacklog
-    
+
     // Should we use Docker's remote API instead of the docker executable
     Boolean useApi
     // URL of the remote Docker host (default: localhost)
@@ -207,7 +207,7 @@ class DockerTask extends DefaultTask {
             dir.mkdirs()
         return dir
     }
-    
+
     @VisibleForTesting
     protected void setupStageDir() {
         logger.info('Setting up staging directory.')
@@ -241,9 +241,9 @@ class DockerTask extends DefaultTask {
 
         if (!dryRun) {
             DockerClient client = getClient()
-            println client.buildImage(stageDir, tag)
+            client.buildImage(stageDir, tag)
             if (push) {
-                println client.pushImage(tag)
+                client.pushImage(tag)
             }
         }
 

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
@@ -28,26 +28,26 @@ class NativeDockerClient implements DockerClient {
     }
 
     @Override
-    String buildImage(File buildDir, String tag) {
+    void buildImage(File buildDir, String tag) {
         Preconditions.checkArgument(tag as Boolean,  "Image tag can not be empty or null.")
         def cmdLine = "${binary} build -t ${tag} ${buildDir}"
-        return executeAndWait(cmdLine)
+        executeAndWait(cmdLine)
     }
 
     @Override
-    String pushImage(String tag) {
+    void pushImage(String tag) {
         Preconditions.checkArgument(tag as Boolean,  "Image tag can not be empty or null.")
         def cmdLine = "${binary} push ${tag}"
-        return executeAndWait(cmdLine)
+        executeAndWait(cmdLine)
     }
 
-    private static String executeAndWait(String cmdLine) {
+    private static void executeAndWait(String cmdLine) {
         def process = cmdLine.execute()
+        process.consumeProcessOutput(System.out as OutputStream, System.err)
         process.waitFor()
         if (process.exitValue()) {
             throw new GradleException("Docker execution failed\nCommand line [${cmdLine}] returned:\n${process.err.text}")
         }
-        return process.in.text
     }
 
 }

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/client/NativeDockerClient.groovy
@@ -30,23 +30,21 @@ class NativeDockerClient implements DockerClient {
     @Override
     void buildImage(File buildDir, String tag) {
         Preconditions.checkArgument(tag as Boolean,  "Image tag can not be empty or null.")
-        def cmdLine = "${binary} build -t ${tag} ${buildDir}"
-        executeAndWait(cmdLine)
+        executeAndWait(binary, 'build', '-t', tag, buildDir.toString())
     }
 
     @Override
     void pushImage(String tag) {
         Preconditions.checkArgument(tag as Boolean,  "Image tag can not be empty or null.")
-        def cmdLine = "${binary} push ${tag}"
-        executeAndWait(cmdLine)
+        executeAndWait(binary, 'push', tag)
     }
 
-    private static void executeAndWait(String cmdLine) {
-        def process = cmdLine.execute()
+    private static void executeAndWait(String... commands) {
+        def process = commands.execute()
         process.consumeProcessOutput(System.out as OutputStream, System.err)
         process.waitFor()
         if (process.exitValue()) {
-            throw new GradleException("Docker execution failed\nCommand line [${cmdLine}] returned:\n${process.err.text}")
+            throw new GradleException("Docker execution failed\nCommand line [${commands}] returned:\n${process.err.text}")
         }
     }
 

--- a/src/main/java/se/transmode/gradle/plugins/docker/client/DockerClient.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/client/DockerClient.java
@@ -18,6 +18,6 @@ package se.transmode.gradle.plugins.docker.client;
 import java.io.File;
 
 public interface DockerClient {
-    public String buildImage(File buildDir, String tag);
-    public String pushImage(String tag);
+    void buildImage(File buildDir, String tag);
+    void pushImage(String tag);
 }

--- a/src/main/java/se/transmode/gradle/plugins/docker/client/JavaDockerClient.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/client/JavaDockerClient.java
@@ -37,28 +37,28 @@ public class JavaDockerClient extends com.github.dockerjava.client.DockerClient 
     }
 
     @Override
-    public String buildImage(File buildDir, String tag) {
+    public void buildImage(File buildDir, String tag) {
         Preconditions.checkNotNull(tag, "Image tag can not be null.");
         Preconditions.checkArgument(!tag.isEmpty(),  "Image tag can not be empty.");
         ClientResponse response = buildImageCmd(buildDir).withTag(tag).exec();
-        return checkResponse(response);
+        checkAndPrintResponse(response);
     }
 
     @Override
-    public String pushImage(String tag) {
+    public void pushImage(String tag) {
         Preconditions.checkNotNull(tag, "Image tag can not be null.");
         Preconditions.checkArgument(!tag.isEmpty(),  "Image tag can not be empty.");
         ClientResponse response = pushImageCmd(tag).exec();
-        return checkResponse(response);
+        checkAndPrintResponse(response);
     }
 
-    private static String checkResponse(ClientResponse response) {
+    private static void checkAndPrintResponse(ClientResponse response) {
         String msg = response.getEntity(String.class);
         if (response.getStatusInfo() != ClientResponse.Status.OK) {
             throw new GradleException(
-                    "Docker API error: Failed to build Image:\n"+msg);
+                "Docker API error: Failed to build Image:\n"+msg);
         }
-        return msg;
+        System.out.println(msg);
     }
 
     public static JavaDockerClient create(String url, String user, String password, String email) {


### PR DESCRIPTION
while creating the command-line for native client, there was no escaping for whitespaces. Using arg-array will prevent errors in such cases.