### PR TITLE
use base java images provided by docker

### DIFF
--- a/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
@@ -21,9 +21,9 @@ import org.gradle.api.JavaVersion;
  * @author Matthias Grüter, matthias.gruter@transmode.com
  */
 public enum JavaBaseImage {
-    JAVA6("fkautz/java6-jre", JavaVersion.VERSION_1_6),
-    JAVA7("dockerfile/java", JavaVersion.VERSION_1_7),
-    JAVA8("aglover/java8-pier", JavaVersion.VERSION_1_8);
+    JAVA6("java:6-jre", JavaVersion.VERSION_1_6),
+    JAVA7("java:7-jre", JavaVersion.VERSION_1_7),
+    JAVA8("java:8-jre", JavaVersion.VERSION_1_8);
 
     final String imageName;
     final JavaVersion target;


### PR DESCRIPTION
These are newer base images provided and curated by Docker.