### PR TITLE
Exposing multiple ports.

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -162,8 +162,8 @@ class DockerTask extends DefaultTask {
         instructions.add("RUN ${command}")
     }
 
-    void exposePort(Integer port) {
-        instructions.add("EXPOSE ${port}")
+    void exposePort(Integer... ports) {
+        instructions.add('EXPOSE ' + ports.join(' ').trim())
     }
 
     void setEnvironment(String key, String value) {

--- a/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
+++ b/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
@@ -65,6 +65,13 @@ class DockerTaskTest {
     }
 
     @Test
+    public void defineExposePorts() {
+        def task = createTask(createProject())
+        task.exposePort(99, 100, 101)
+        assertThat "EXPOSE ${99} ${100} ${101}".toString(), isIn(task.buildDockerfile().instructions)
+    }
+
+    @Test
     public void nonJavaDefaultBaseImage() {
         def project = createProject()
         def task = createTask(project)


### PR DESCRIPTION
Enabling the EXPOSE instruction's ability to allow the container to listen on multiple network ports.
See: https://docs.docker.com/engine/reference/builder/#expose