### PR TITLE
Adds certPath and apiVersion configuration to use of remote Docker API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ docker {
 Use of the remote API requires that the Docker server be configured to listen over HTTP and that it have support for version 1.11 of the API (connecting over Unix Domain sockets is not supported yet).  The following configuration options are available:
 
 * `hostUrl` - set the URL used to contact the Docker server.  Defaults to `http://localhost:2375`
+* `certPath` - set the path to the authentication keys.  Defaults to `nil` which means no certificate is provided.
+* `apiVersion` - set version of the Docker API.  Defaults to `nil` which means DOCKER_API_VERSION is used.
 * `apiUsername` - set the username used to authenticate the user with the Docker server.  Defaults to `nil` which means no authentication is performed.
 * `apiPassword` - set the password used to authenticate the user with the Docker server.
 * `apiEmail` - set the user's email used to authenticate the user with the Docker server.
@@ -150,6 +152,8 @@ For example:
 docker {
     useApi true
     hostUrl 'http://myserver:4243'
+    certPath '/home/me/.minikube/certs'
+    apiVersion '1.23'
     apiUsername 'user'
     apiPassword 'password'
     apiEmail 'me@mycompany.com'

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPlugin.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPlugin.groovy
@@ -80,6 +80,8 @@ class DockerPlugin implements Plugin<Project> {
             registry = ''
             useApi = Boolean.FALSE
             hostUrl = ''
+            certPath = ''
+            apiVersion = ''
             apiUsername = ''
             apiEmail = ''
             apiPassword = ''
@@ -111,6 +113,8 @@ class DockerPlugin implements Plugin<Project> {
             registry = { extension.registry }
             useApi = { extension.useApi }
             hostUrl = { extension.hostUrl }
+            certPath = { extension.certPath }
+            apiVersion = { extension.apiVersion }
             apiUsername = { extension.apiUsername }
             apiPassword = { extension.apiPassword }
             apiEmail = { extension.apiEmail }
@@ -125,6 +129,8 @@ class DockerPlugin implements Plugin<Project> {
             registry = { extension.registry }
             useApi = { extension.useApi }
             hostUrl = { extension.hostUrl }
+            certPath = { extension.certPath }
+            apiVersion = { extension.apiVersion }
             apiUsername = { extension.apiUsername }
             apiPassword = { extension.apiPassword }
             apiEmail = { extension.apiEmail }

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPluginExtension.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerPluginExtension.groovy
@@ -28,6 +28,8 @@ class DockerPluginExtension {
 
     // docker host url & credentials
     String hostUrl
+    String certPath
+    String apiVersion
     String apiUsername
     String apiEmail
     String apiPassword

--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTaskBase.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTaskBase.groovy
@@ -51,6 +51,12 @@ abstract class DockerTaskBase extends DefaultTask {
     String apiUsername
     String apiPassword
     String apiEmail
+
+    // Docker remote certificate
+    String certPath
+
+    // Docker remote API version
+    String apiVersion
     
     DockerTaskBase() {
         applicationName = project.name
@@ -100,7 +106,9 @@ abstract class DockerTaskBase extends DefaultTask {
                     getHostUrl(),
                     getApiUsername(),
                     getApiPassword(),
-                    getApiEmail())
+                    getApiEmail(),
+                    getApiVersion(),
+                    getCertPath())
         } else {
             logger.info("Using the native docker binary.")
             client = new NativeDockerClient(getDockerBinary())

--- a/src/main/java/se/transmode/gradle/plugins/docker/client/JavaDockerClient.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/client/JavaDockerClient.java
@@ -44,13 +44,19 @@ public class JavaDockerClient implements DockerClient {
         this.dockerClient = dockerClient;
     }
 
-    public static JavaDockerClient create(String url, String user, String password, String email) {
+    public static JavaDockerClient create(String url, String user, String password, String email, String apiVersion, String certPath) {
         final DockerClientConfig.DockerClientConfigBuilder configBuilder = DockerClientConfig.createDefaultConfigBuilder();
         if (StringUtils.isEmpty(url)) {
             log.info("Connecting to localhost");
         } else {
             log.info("Connecting to {}", url);
             configBuilder.withUri(url);
+        }
+        if (StringUtils.isNotEmpty(apiVersion)) {
+            configBuilder.withVersion(apiVersion);
+        }
+        if (StringUtils.isNotEmpty(certPath)) {
+            configBuilder.withDockerCertPath(certPath);
         }
         if (StringUtils.isNotEmpty(user)) {
             configBuilder.withUsername(user).withPassword(password).withEmail(email);


### PR DESCRIPTION
Implements `certPath` and `apiVersion` of #123 . docker-java needs to updated to be able to add `tlsVerify` as well.