### PR TITLE
Fixes a bug where an exception is not caught in java 9

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -95,7 +95,14 @@ class DockerTask extends DockerTaskBase {
      * @return Name of base docker image
      */
     public String getBaseImage() {
-        def defaultImage = project.hasProperty('targetCompatibility') ? JavaBaseImage.imageFor(project.targetCompatibility).imageName : DEFAULT_IMAGE
+        def defaultImage = DEFAULT_IMAGE;
+        if(project.hasProperty('targetCompatibility')) {
+            try {
+                defaultImage = JavaBaseImage.imageFor(project.targetCompatibility).imageName
+            } catch (IllegalArgumentException e) {
+                logger.warn("Failed to determine default image of java target", e)
+            }
+        }
         return baseImage ?: (project[DockerPlugin.EXTENSION_NAME].baseImage ?: defaultImage)
     }
 

--- a/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
@@ -23,7 +23,8 @@ import org.gradle.api.JavaVersion;
 public enum JavaBaseImage {
     JAVA6("openjdk:6-jre", JavaVersion.VERSION_1_6),
     JAVA7("openjdk:7-jre", JavaVersion.VERSION_1_7),
-    JAVA8("openjdk:8-jre", JavaVersion.VERSION_1_8);
+    JAVA8("openjdk:8-jre", JavaVersion.VERSION_1_8),
+    JAVA9("openjdk:9-jre", JavaVersion.VERSION_1_9);
 
     final String imageName;
     final JavaVersion target;

--- a/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
+++ b/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
@@ -114,6 +114,18 @@ class DockerTaskTest {
                 is(equalTo(JavaBaseImage.imageFor(testVersion).imageName))
     }
 
+    @Test
+    public void handlesUnsupportedJavaVersionGracefully() {
+        def project = createProject()
+        project.apply plugin: 'java'
+        def task = createTask(project)
+        def testVersion = JavaVersion.VERSION_1_1
+        project.targetCompatibility = testVersion
+        task.baseImage = "taskBase"
+        assertThat project[DockerPlugin.EXTENSION_NAME].baseImage, is(nullValue())
+        assertThat task.baseImage, is(equalTo("taskBase"))
+    }
+
     // @fixme: this is an integration test!
     @Test
     public void testAddFileWithDir() {


### PR DESCRIPTION
If targetCompatibility is set to a value not supported by the JavaBaseImage class (eg. 1.1) an exception is thrown but never handled. Thus the build aborts.

Also added support for openjdk-9 base images as default images (which would also fix the behavior for java 9, but not the root cause)