### PR TITLE
Fix DockerTask.getBaseImage() and add Java 9 base image

### DIFF
--- a/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
+++ b/src/main/groovy/se/transmode/gradle/plugins/docker/DockerTask.groovy
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 package se.transmode.gradle.plugins.docker
+
 import com.google.common.annotations.VisibleForTesting
-import com.google.common.io.Files
 import org.gradle.api.Task
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -85,6 +85,7 @@ class DockerTask extends DockerTaskBase {
      * Name of base docker image
     */
     String baseImage
+
     /**
      * Return the base docker image.
      *
@@ -95,10 +96,18 @@ class DockerTask extends DockerTaskBase {
      * @return Name of base docker image
      */
     public String getBaseImage() {
-        def defaultImage = project.hasProperty('targetCompatibility') ? JavaBaseImage.imageFor(project.targetCompatibility).imageName : DEFAULT_IMAGE
-        return baseImage ?: (project[DockerPlugin.EXTENSION_NAME].baseImage ?: defaultImage)
+        if (baseImage) {
+            return baseImage
+        }
+        def projectBaseImage = project[DockerPlugin.EXTENSION_NAME].baseImage
+        if (projectBaseImage) {
+            return projectBaseImage
+        } else if (project.hasProperty('targetCompatibility')) {
+            return JavaBaseImage.imageFor(project.targetCompatibility).imageName
+        } else {
+            return DEFAULT_IMAGE
+        }
     }
-
 
     // Dockerfile instructions (ADD, RUN, etc.)
     def instructions

--- a/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
+++ b/src/main/java/se/transmode/gradle/plugins/docker/JavaBaseImage.java
@@ -23,7 +23,8 @@ import org.gradle.api.JavaVersion;
 public enum JavaBaseImage {
     JAVA6("openjdk:6-jre", JavaVersion.VERSION_1_6),
     JAVA7("openjdk:7-jre", JavaVersion.VERSION_1_7),
-    JAVA8("openjdk:8-jre", JavaVersion.VERSION_1_8);
+    JAVA8("openjdk:8-jre", JavaVersion.VERSION_1_8),
+    JAVA9("openjdk:9-jre", JavaVersion.VERSION_1_9);
 
     final String imageName;
     final JavaVersion target;

--- a/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
+++ b/src/test/groovy/se/transmode/gradle/plugins/docker/DockerTaskTest.groovy
@@ -88,6 +88,16 @@ class DockerTaskTest {
     }
 
     @Test
+    public void projectBaseImageHasPrecedence() {
+        def project = createProject()
+        project[DockerPlugin.EXTENSION_NAME].baseImage = 'dummyImage'
+        project.apply plugin: 'java'
+        project.setProperty('targetCompatibility', JavaVersion.VERSION_1_1)
+        def task = createTask(project)
+        assertThat task.baseImage, is(equalTo('dummyImage'))
+    }
+
+    @Test
     public void overrideBaseImageInExtension() {
         def project = createProject()
         def task = createTask(project)


### PR DESCRIPTION
The `DockerTask.getBaseImage()` method is currently not implemented correctly.

I had the following setup:
```
sourceCompatibility = JavaVersion.VERSION_1_9
targetCompatibility = JavaVersion.VERSION_1_9

docker {
    baseImage = "openjdk:9-jre"
}
```

and it still failed with:
```
Caused by: java.lang.IllegalArgumentException: No Java base image for the supplied target 1.9 found.
        at se.transmode.gradle.plugins.docker.JavaBaseImage.imageFor(JavaBaseImage.java:42)
        at se.transmode.gradle.plugins.docker.JavaBaseImage$imageFor.call(Unknown Source)
        at se.transmode.gradle.plugins.docker.DockerTask.determineBaseImage(DockerTask.groovy:81)
```

This is due to the fact that the base image for the specified Java version is still retrieved (and fails). In this case there is no need to retrieve it as an explicit base image is specified.